### PR TITLE
Extended Prefix Matching For Unlimited IDs

### DIFF
--- a/Callback_Management.php
+++ b/Callback_Management.php
@@ -101,7 +101,7 @@ class Callback_Management
     public function getSubPrefixHints($content, $prefix)
     {
         $match = array();
-        $pattern = '/\[(' . $prefix . '(-[a-z])?):/i';
+        $pattern = '/\[(' . $prefix . '(-[a-z][a-z0-9]*)?):/i';
         $isOk = @preg_match_all($pattern, $content, $match);
 
         if ($isOk === false) {

--- a/Tests/Callback_ManagementTest.php
+++ b/Tests/Callback_ManagementTest.php
@@ -148,10 +148,11 @@ class Callback_ManagementTest extends PHPUnit_Framework_TestCase
         $mgmt = new Callback_Management();
         $content = 'Pellentesque viverra luctus est, vel bibendum arcu '
             . 'suscipit quis. ÖÄÅ öäå Quisque congue[IMDblive:id(tt0137523)]. '
-            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremo]'
-            . '[imdblive-z:posterremo]';
+            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremote]'
+            . '[imdblive-z:posterremote] [imdblive-aa:posterremote]'
+            . '[imdblive-f0001:posterremote] [imdblive-fightclub:posterremote]';
         $prefix = 'imdblive';
-        $expected = array('imdblive', 'imdblive-a', 'imdblive-z');
+        $expected = array('imdblive', 'imdblive-a', 'imdblive-z', 'imdblive-aa', 'imdblive-f0001', 'imdblive-fightclub');
 
         //When
         $actual = $mgmt->getSubPrefixHints($content, $prefix);
@@ -177,7 +178,7 @@ class Callback_ManagementTest extends PHPUnit_Framework_TestCase
         $mgmt = new Callback_Management();
         $content = 'Pellentesque viverra luctus est, vel bibendum arcu '
             . 'suscipit quis. ÖÄÅ öäå Quisque congue[IMDblive:id(tt0137523)]. '
-            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterreme]';
+            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremote]';
         $prefix = '(';
 
         //When


### PR DESCRIPTION
Addresses GitHub Issue #8

Expanded regex used for prefix matching to allow more than 26 IDs per post field
- IDs must still start with a letter from a-z, ASCII/UTF-8
- Second and later characters, if they exist, may be a-z or 0-9, ASCII/UTF-8

Extended testGetSubPrefixHints to cover multi-character IDs
- Added test for imdblive-aa
- Added test for imdblive-f0001
- Added test for imdblive-fightclub (to showcase how these IDs might be used
  to more easily keep track of which ID refers to which title)

Unable to run tests in my current environment, so this code will need to be
reviewed prior to merge, but it should work without issue.

Signed-off-by: Dan Hunsaker danhunsaker@gmail.com
