### PR TITLE
Added support for one-off tags with embedded IDs

### DIFF
--- a/Callback_Management.php
+++ b/Callback_Management.php
@@ -101,7 +101,7 @@ class Callback_Management
     public function getSubPrefixHints($content, $prefix)
     {
         $match = array();
-        $pattern = '/\[(' . $prefix . '(-[a-z])?):/i';
+        $pattern = '/\[(' . $prefix . '(-[a-z][a-z0-9]*)?):/i';
         $isOk = @preg_match_all($pattern, $content, $match);
 
         if ($isOk === false) {

--- a/Tests/Callback_ManagementTest.php
+++ b/Tests/Callback_ManagementTest.php
@@ -148,10 +148,11 @@ class Callback_ManagementTest extends PHPUnit_Framework_TestCase
         $mgmt = new Callback_Management();
         $content = 'Pellentesque viverra luctus est, vel bibendum arcu '
             . 'suscipit quis. ÖÄÅ öäå Quisque congue[IMDblive:id(tt0137523)]. '
-            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremo]'
-            . '[imdblive-z:posterremo]';
+            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremote]'
+            . '[imdblive-z:posterremote] [imdblive-aa:posterremote]'
+            . '[imdblive-f0001:posterremote] [imdblive-fightclub:posterremote]';
         $prefix = 'imdblive';
-        $expected = array('imdblive', 'imdblive-a', 'imdblive-z');
+        $expected = array('imdblive', 'imdblive-a', 'imdblive-z', 'imdblive-aa', 'imdblive-f0001', 'imdblive-fightclub');
 
         //When
         $actual = $mgmt->getSubPrefixHints($content, $prefix);
@@ -177,7 +178,7 @@ class Callback_ManagementTest extends PHPUnit_Framework_TestCase
         $mgmt = new Callback_Management();
         $content = 'Pellentesque viverra luctus est, vel bibendum arcu '
             . 'suscipit quis. ÖÄÅ öäå Quisque congue[IMDblive:id(tt0137523)]. '
-            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterreme]';
+            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremote]';
         $prefix = '(';
 
         //When

--- a/Tests/Callback_ManagementTest.php
+++ b/Tests/Callback_ManagementTest.php
@@ -148,14 +148,39 @@ class Callback_ManagementTest extends PHPUnit_Framework_TestCase
         $mgmt = new Callback_Management();
         $content = 'Pellentesque viverra luctus est, vel bibendum arcu '
             . 'suscipit quis. ÖÄÅ öäå Quisque congue[IMDblive:id(tt0137523)]. '
-            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremote]'
-            . '[imdblive-z:posterremote] [imdblive-aa:posterremote]'
+            . 'Posterremote: [imdblive-a:posterremote] [imdblive-z:posterremote] '
+            . '[imdblive-z:posterremote] [imdblive-aa:posterremote] '
             . '[imdblive-f0001:posterremote] [imdblive-fightclub:posterremote]';
         $prefix = 'imdblive';
         $expected = array('imdblive', 'imdblive-a', 'imdblive-z', 'imdblive-aa', 'imdblive-f0001', 'imdblive-fightclub');
 
         //When
         $actual = $mgmt->getSubPrefixHints($content, $prefix);
+
+        //Then
+        $this->assertSame($expected, $actual);
+    }
+
+    /**
+     * Positive test
+     *
+     * @covers Callback_Management::convertOneOffToSubPrefix
+     * @return void
+     */
+    public function testConvertOneOffToSubPrefix()
+    {
+        //Given
+        $mgmt = new Callback_Management();
+        $content = 'Pellentesque viverra luctus est, vel bibendum arcu '
+            . 'suscipit quis. ÖÄÅ öäå Quisque congue. '
+            . 'Posterremote: [imdb:posterremote(tt0137523)]';
+        $expected = '[imdb-tt0137523:id(tt0137523)]Pellentesque viverra luctus est, vel bibendum arcu '
+            . 'suscipit quis. ÖÄÅ öäå Quisque congue. '
+            . 'Posterremote: [imdb-tt0137523:posterremote]';
+        $prefix = 'imdb';
+
+        //When
+        $actual = $mgmt->convertOneOffToSubPrefix($content, $prefix);
 
         //Then
         $this->assertSame($expected, $actual);


### PR DESCRIPTION
New proposed feature

This PR relies on PR #10 to merge cleanly, as the implementation needs access to longer tags.
That means that it is automatically included in this PR as well, and has become redundant.

Added support for embedded IDs in a one-off style.
- User places `[imdb:title(tt0137523)]` in a post to quickly generate a link.
- New code searches for `[imdb:<tagname>(<id>)]` and converts it to `[imdb-<id>:<tagname>]`.
- New code also adds `[imdb-<id>:id(<id>)]` to the beginning of the post.
- Processing continues normally from there.

Also works with `[imdblive:<tagname>(<id>)]`.

Tested in PHPStorm 7 to work correctly.

Signed-off-by: Dan Hunsaker danhunsaker@gmail.com
